### PR TITLE
refactor: make decodeFromBase64 throw IllegalArgumentException on invalid input

### DIFF
--- a/src/commonMain/kotlin/dev/sriniketh/EncodingDecoding.kt
+++ b/src/commonMain/kotlin/dev/sriniketh/EncodingDecoding.kt
@@ -33,5 +33,11 @@ fun encodeToBase64(content: String): String = content.encodeUtf8().base64()
  *
  * @param[encodedContent] Content to be decoded.
  * @return Decoded string.
+ * @throws IllegalArgumentException
  */
-fun decodeFromBase64(encodedContent: String): String? = encodedContent.decodeBase64()?.utf8()
+@Throws(IllegalArgumentException::class)
+fun decodeFromBase64(encodedContent: String): String {
+    val decoded = encodedContent.decodeBase64()
+        ?: throw IllegalArgumentException("Invalid base64 input: $encodedContent")
+    return decoded.utf8()
+}

--- a/src/commonTest/kotlin/dev/sriniketh/EncodingDecodingTest.kt
+++ b/src/commonTest/kotlin/dev/sriniketh/EncodingDecodingTest.kt
@@ -2,7 +2,7 @@ package dev.sriniketh
 
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
+import kotlin.test.assertFailsWith
 
 class EncodingDecodingTest {
 
@@ -31,8 +31,9 @@ class EncodingDecodingTest {
     }
 
     @Test
-    fun `decodeFromBase64 returns null when provided with invalid base64 input`() {
-        val result = decodeFromBase64("4rdHF")
-        assertNull(result)
+    fun `decodeFromBase64 throws IllegalArgumentException when provided with invalid base64 input`() {
+        assertFailsWith<IllegalArgumentException> {
+            decodeFromBase64("4rdHF")
+        }
     }
 }

--- a/src/nativeMain/kotlin/dev/sriniketh/DecodingCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/DecodingCommand.kt
@@ -37,10 +37,9 @@ internal class DecodingCommand : CliktCommand(name = "decode") {
 
             "base64" -> {
                 echo("input string: $content")
-                val decoded = decodeFromBase64(content)
-                if (decoded != null) {
-                    echo("decoded string: $decoded")
-                } else {
+                try {
+                    echo("decoded string: ${decodeFromBase64(content)}")
+                } catch (_: IllegalArgumentException) {
                     echo("Invalid base64 input: $content")
                 }
             }


### PR DESCRIPTION
## Summary
- Changed `decodeFromBase64` return type from `String?` to `String`, throwing `IllegalArgumentException` on invalid base64 input
- Updated `DecodingCommand` to catch the exception instead of null-checking the result
- Updated unit test to assert exception is thrown instead of asserting null return

## Test Plan
- [ ] `./gradlew allTests` passes
- [ ] `./gradlew detektMetadataCommonMain` passes
- [ ] `./gradlew detektMacosArm64Main` passes
- [ ] CLI behavior for invalid base64 still prints `"Invalid base64 input: ..."` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)