### PR TITLE
fix: replace deprecated URL constructor with URI.toURL()

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jetbrains.dokka.DokkaConfiguration.Visibility
 import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 import java.io.ByteArrayOutputStream
-import java.net.URL
+import java.net.URI
 
 plugins {
     alias(libs.plugins.multiplatform)
@@ -83,7 +83,7 @@ tasks.withType<DokkaTask>().configureEach {
         sourceLink {
             localDirectory.set(file("src/$name/kotlin"))
             remoteUrl.set(
-                URL("https://github.com/sriniketh/ktools/tree/main/src/$name/kotlin")
+                URI("https://github.com/sriniketh/ktools/tree/main/src/$name/kotlin").toURL()
             )
             remoteLineSuffix.set("#L")
         }


### PR DESCRIPTION
## Summary
- Replace `import java.net.URL` with `import java.net.URI` in `build.gradle.kts`
- Replace `URL(...)` constructor call with `URI(...).toURL()` for Dokka source link config
- Future-proofs the build script against the Java 20+ deprecation of `java.net.URL(String)`

## Test Plan
- [x] `./gradlew build` passes (45 tasks executed)