### PR TITLE
refactor: deduplicate algorithm branches in HashCommand

### DIFF
--- a/docs/superpowers/plans/2026-04-12-share-json-instance-in-prettyprint.md
+++ b/docs/superpowers/plans/2026-04-12-share-json-instance-in-prettyprint.md
@@ -1,0 +1,85 @@
+# Share Json Instance in PrettyPrint Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Extract the shared `Json { prettyPrint = true }` instance in `PrettyPrint.kt` to avoid creating a new one per function call.
+
+**Architecture:** Move the `Json` instance to a file-level `private val`, referenced by both `prettyPrintJson` and `prettyPrintCookieHeader`. This matches the pattern already used in `AboutOption.kt:10`.
+
+**Tech Stack:** kotlinx-serialization-json
+
+---
+
+### File Structure
+
+- Modify: `src/commonMain/kotlin/dev/sriniketh/PrettyPrint.kt` — extract shared Json instance
+
+---
+
+### Task 1: Extract shared Json instance
+
+**Files:**
+- Modify: `src/commonMain/kotlin/dev/sriniketh/PrettyPrint.kt`
+- Test: `src/commonTest/kotlin/dev/sriniketh/PrettyPrintTest.kt` (existing — no changes needed)
+
+- [ ] **Step 1: Run existing tests to establish baseline**
+
+Run: `./gradlew allTests`
+Expected: All tests PASS.
+
+- [ ] **Step 2: Refactor PrettyPrint.kt to share the Json instance**
+
+Replace the entire content of `src/commonMain/kotlin/dev/sriniketh/PrettyPrint.kt` with:
+
+```kotlin
+package dev.sriniketh
+
+import io.ktor.http.parseClientCookiesHeader
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+
+private val prettyJson = Json { prettyPrint = true }
+
+/**
+ * Pretty prints given json string.
+ *
+ * @param[jsonString] JSON string that needs to be formatted.
+ * @return Formatted json string.
+ * @throws IllegalArgumentException
+ * @throws SerializationException
+ */
+@Throws(IllegalArgumentException::class, SerializationException::class)
+fun prettyPrintJson(jsonString: String): String {
+    val jsonElement = prettyJson.decodeFromString<JsonElement>(jsonString)
+    return prettyJson.encodeToString(jsonElement)
+}
+
+/**
+ * Pretty prints given Cookie header value.
+ *
+ * @param[cookieHeader] Cookie header that needs to be formatted.
+ * @return Formatted Cookie header.
+ */
+fun prettyPrintCookieHeader(cookieHeader: String): String {
+    val cookiesMap = parseClientCookiesHeader(cookieHeader)
+    return prettyJson.encodeToString(cookiesMap)
+}
+```
+
+- [ ] **Step 3: Run all tests**
+
+Run: `./gradlew allTests`
+Expected: All tests PASS with identical output.
+
+- [ ] **Step 4: Run detekt**
+
+Run: `./gradlew detektMetadataCommonMain`
+Expected: No new violations.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/commonMain/kotlin/dev/sriniketh/PrettyPrint.kt
+git commit -m "refactor: share Json instance across PrettyPrint functions"
+```

--- a/src/nativeMain/kotlin/dev/sriniketh/HashCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/HashCommand.kt
@@ -46,48 +46,23 @@ internal class HashCommand(private val fileSystem: FileSystem = FileSystem.SYSTE
     override fun help(context: Context): String = "Get hash value for given file or string"
 
     override fun run() {
-        when (algorithm.lowercase()) {
-            "md5" -> {
-                when (val it = content) {
-                    is FileContent -> printHashForFileOrExceptionIfFailure { fileMD5(it.path, fileSystem) }
-                    is StringContent -> {
-                        echo("input string: ${it.text}")
-                        echo("hash: ${stringMD5(it.text)}")
-                    }
-                }
+        val (fileHashFn, stringHashFn) = when (algorithm.lowercase()) {
+            "md5" -> ::fileMD5 to ::stringMD5
+            "sha1" -> ::fileSHA1 to ::stringSHA1
+            "sha256" -> ::fileSHA256 to ::stringSHA256
+            "sha512" -> ::fileSHA512 to ::stringSHA512
+            else -> {
+                echo("Unsupported option: $algorithm")
+                return
             }
+        }
 
-            "sha1" -> {
-                when (val it = content) {
-                    is FileContent -> printHashForFileOrExceptionIfFailure { fileSHA1(it.path, fileSystem) }
-                    is StringContent -> {
-                        echo("input string: ${it.text}")
-                        echo("hash: ${stringSHA1(it.text)}")
-                    }
-                }
+        when (val it = content) {
+            is FileContent -> printHashForFileOrExceptionIfFailure { fileHashFn(it.path, fileSystem) }
+            is StringContent -> {
+                echo("input string: ${it.text}")
+                echo("hash: ${stringHashFn(it.text)}")
             }
-
-            "sha256" -> {
-                when (val it = content) {
-                    is FileContent -> printHashForFileOrExceptionIfFailure { fileSHA256(it.path, fileSystem) }
-                    is StringContent -> {
-                        echo("input string: ${it.text}")
-                        echo("hash: ${stringSHA256(it.text)}")
-                    }
-                }
-            }
-
-            "sha512" -> {
-                when (val it = content) {
-                    is FileContent -> printHashForFileOrExceptionIfFailure { fileSHA512(it.path, fileSystem) }
-                    is StringContent -> {
-                        echo("input string: ${it.text}")
-                        echo("hash: ${stringSHA512(it.text)}")
-                    }
-                }
-            }
-
-            else -> echo("Unsupported option: $algorithm")
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replaced 4 duplicated `when (algorithm)` + `when (content)` branches with a single dispatch table mapping algorithm names to function reference pairs
- `run()` reduced from ~45 lines to ~20 lines with no behavior change

## Test Plan
- [x] All existing tests pass (`./gradlew allTests`)
- [x] Detekt reports no new violations (`./gradlew detektMacosArm64Main`)