### PR TITLE
refactor: hide internal packages and main() from Dokka docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,6 +78,7 @@ dokka {
             remoteUrl("https://github.com/sriniketh/ktools/tree/main/src/$name/kotlin")
             remoteLineSuffix.set("#L")
         }
+        suppressedFiles.from(file("src/$name/kotlin/dev/sriniketh/Main.kt"))
     }
 }
 

--- a/src/commonMain/kotlin/dev/sriniketh/helpers/File.kt
+++ b/src/commonMain/kotlin/dev/sriniketh/helpers/File.kt
@@ -17,7 +17,7 @@ import okio.Path.Companion.toPath
  * @throws IllegalArgumentException
  */
 @Throws(IOException::class, SerializationException::class, IllegalArgumentException::class)
-inline fun <reified T> parseFile(
+internal inline fun <reified T> parseFile(
     filepath: String,
     ignoreUnknownKeys: Boolean = true,
     fileSystem: FileSystem = FileSystem.SYSTEM

--- a/src/nativeMain/kotlin/dev/sriniketh/models/LibrariesAndLicenses.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/models/LibrariesAndLicenses.kt
@@ -3,20 +3,20 @@ package dev.sriniketh.models
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LibrariesAndLicenses(
+internal data class LibrariesAndLicenses(
     val libraries: List<Library>,
     val licenses: Map<String, License>
 )
 
 @Serializable
-data class Library(
+internal data class Library(
     val name: String?,
     val uniqueId: String,
     val artifactVersion: String?
 )
 
 @Serializable
-data class License(
+internal data class License(
     val name: String,
     val url: String?
 )


### PR DESCRIPTION
## Summary
- Made `parseFile()` in `dev.sriniketh.helpers` package `internal` to exclude from Dokka docs
- Made `LibrariesAndLicenses`, `Library`, `License` model classes `internal` to exclude from Dokka docs
- Added `suppressedFiles` config for `Main.kt` since the entry point `main()` function cannot be made `internal`

Dokka V2 only documents `PUBLIC`/`PROTECTED` by default, so `internal` visibility automatically hides these from generated documentation.

## Test plan
- [x] `./gradlew allTests` — all tests pass (internal is visible to same-module test sources)
- [x] `./gradlew compileKotlinMacosArm64` — compiles successfully
- [x] `./gradlew dokkaGenerate` — verified `dev.sriniketh.helpers/`, `dev.sriniketh.models/`, and `main.html` are no longer in output
- [x] Public API docs (UUID, hash, encoding functions, etc.) still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)