### PR TITLE
chore(deps): update aboutlibraries plugin to v15.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,7 +33,7 @@ kotlin {
             executable {
                 baseName = "ktools"
                 entryPoint = "dev.sriniketh.main"
-                runTask?.run {
+                runTaskProvider?.configure {
                     val args = providers.gradleProperty("runArgs")
                     argumentProviders.add(CommandLineArgumentProvider {
                         args.orNull?.split(' ') ?: emptyList()
@@ -85,8 +85,8 @@ dokka {
 // about libraries plugin config
 aboutLibraries {
     export {
-        outputFileName.set("librariesandlicenses.json")
-        prettyPrint.set(true)
+        outputFile = file("src/nativeMain/resources/librariesandlicenses.json")
+        prettyPrint = true
     }
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,7 +16,7 @@ dependencyResolutionManagement {
             plugin("multiplatform", "org.jetbrains.kotlin.multiplatform").versionRef("kotlin")
             plugin("serialization", "org.jetbrains.kotlin.plugin.serialization").versionRef("kotlin")
             plugin("dokka", "org.jetbrains.dokka").version("2.2.0")
-            plugin("aboutlibraries", "com.mikepenz.aboutlibraries.plugin").version("13.2.1")
+            plugin("aboutlibraries", "com.mikepenz.aboutlibraries.plugin").version("15.0.2")
             plugin("buildconfig", "com.github.gmazzo.buildconfig").version("6.0.10")
             plugin("detekt", "io.gitlab.arturbosch.detekt").version("1.23.8")
 


### PR DESCRIPTION
## Summary

- Bumps `com.mikepenz.aboutlibraries.plugin` from `13.2.1` → `15.0.2`
- Migrates the Gradle DSL to the v15 API (`outputFile = file(...)` replaces the removed `outputFileName.set(...)`)
- Updates `prettyPrint` to property-assignment style (`prettyPrint = true`)
- Replaces deprecated `runTask?.run {}` with `runTaskProvider?.configure {}`

## Why a manual PR instead of Renovate #112?

Renovate PR #112 only bumps the version; it can't also migrate the breaking API change in `build.gradle.kts`. This PR does both together so CI passes.

Closes #112

## Test plan

- [ ] CI passes on all three platforms (Linux, macOS, Windows)
- [ ] `exportLibraryDefinitions` task still generates `src/nativeMain/resources/librariesandlicenses.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)