### PR TITLE
fix(ci): upload test reports even when build fails

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           arguments: build
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-macos
@@ -47,6 +48,7 @@ jobs:
         with:
           arguments: build
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-linux
@@ -68,6 +70,7 @@ jobs:
         with:
           arguments: build
       - name: Save test results
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: test-results-windows


### PR DESCRIPTION
## Summary
- Test reports are now uploaded even when the build/test step fails, so failures are debuggable from CI artifacts.

## Test plan
- YAML validated locally with `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/build.yml'))"`.
- Needs to be confirmed by watching the next `build.yml` run where tests actually fail, since the behavior only differs on failure.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>