### PR TITLE
fix(ci): migrate from deprecated gradle/gradle-build-action to gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,10 +21,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: build
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew build
       - name: Save test results
         uses: actions/upload-artifact@v7
         with:
@@ -42,10 +44,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: build
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew build
       - name: Save test results
         uses: actions/upload-artifact@v7
         with:
@@ -63,10 +67,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: build
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew build
       - name: Save test results
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,9 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Gradle
-        uses: gradle/gradle-build-action@v3
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          validate-wrappers: true
       - name: Generate dokka docs
         run: ./gradlew dokkaGeneratePublicationHtml
       - uses: actions/setup-python@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: macosArm64Binaries
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew macosArm64Binaries
       - name: Upload macos Arm build
         uses: actions/upload-artifact@v7
         with:
@@ -41,10 +43,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: macosX64Binaries
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew macosX64Binaries
       - name: Upload macos X64 build
         uses: actions/upload-artifact@v7
         with:
@@ -62,10 +66,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: linuxX64Binaries
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew linuxX64Binaries
       - name: Upload linux X64 build
         uses: actions/upload-artifact@v7
         with:
@@ -83,10 +89,12 @@ jobs:
         with:
           java-version: '17'
           distribution: 'zulu'
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@v3
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
         with:
-          arguments: mingwX64Binaries
+          validate-wrappers: true
+      - name: Build with Gradle
+        run: ./gradlew mingwX64Binaries
       - name: Upload windows X64 build
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
## Summary
- Replaces the unmaintained `gradle/gradle-build-action@v3` (8 invocations across `build.yml`, `release.yml`, `docs.yml`) with the actively maintained `gradle/actions/setup-gradle@v6`, followed by explicit `run: ./gradlew ...` steps that preserve the exact same Gradle invocations each job previously ran via the `arguments:` input.
- Enables `validate-wrappers: true` on every new setup-gradle step, which also closes the separate "no Gradle wrapper integrity verification" finding as a side effect.
- No changes to job structure, permissions, checkout/setup-java steps, or artifact upload steps.

## Test plan
- [x] Validated YAML syntax locally for all 3 workflow files (`build.yml`, `release.yml`, `docs.yml`)
- [ ] Confirm actual build/cache behavior on the next CI run — setup-gradle's caching and wrapper-validation behavior can't be fully verified without running in GitHub Actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)