### PR TITLE
fix(cli): route runtime errors to stderr, exit non-zero

### DIFF
--- a/src/nativeMain/kotlin/dev/sriniketh/DecodingCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/DecodingCommand.kt
@@ -2,6 +2,7 @@ package dev.sriniketh
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.option
@@ -31,7 +32,7 @@ internal class DecodingCommand : CliktCommand(name = "decode") {
                 try {
                     echo("decoded string: ${decodeFromUTF8Hex(content)}")
                 } catch (_: IllegalArgumentException) {
-                    echo("Invalid UTF-8 hex input: $content")
+                    throw PrintMessage("Invalid UTF-8 hex input: $content", statusCode = 1, printError = true)
                 }
             }
 
@@ -40,7 +41,7 @@ internal class DecodingCommand : CliktCommand(name = "decode") {
                 try {
                     echo("decoded string: ${decodeFromBase64(content)}")
                 } catch (_: IllegalArgumentException) {
-                    echo("Invalid base64 input: $content")
+                    throw PrintMessage("Invalid base64 input: $content", statusCode = 1, printError = true)
                 }
             }
 

--- a/src/nativeMain/kotlin/dev/sriniketh/HashCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/HashCommand.kt
@@ -2,6 +2,7 @@ package dev.sriniketh
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.required
@@ -40,7 +41,7 @@ internal class HashCommand(private val fileSystem: FileSystem = FileSystem.SYSTE
         try {
             echo("hash: ${block.invoke()}")
         } catch (exception: IOException) {
-            echo("IOException: ${exception.message}")
+            throw PrintMessage("IOException: ${exception.message}", statusCode = 1, printError = true)
         }
 
     override fun help(context: Context): String = "Get hash value for given file or string"

--- a/src/nativeMain/kotlin/dev/sriniketh/PrettyPrintCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/PrettyPrintCommand.kt
@@ -2,6 +2,7 @@ package dev.sriniketh
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.arguments.argument
 import com.github.ajalt.clikt.parameters.options.check
 import com.github.ajalt.clikt.parameters.options.option
@@ -32,9 +33,17 @@ internal class PrettyPrintCommand : CliktCommand(name = "prettyprint") {
                     echo()
                     echo(prettyPrintJson(content))
                 } catch (exception: IllegalArgumentException) {
-                    echo("IllegalArgumentException: ${exception.message}")
+                    throw PrintMessage(
+                        "IllegalArgumentException: ${exception.message}",
+                        statusCode = 1,
+                        printError = true
+                    )
                 } catch (exception: SerializationException) {
-                    echo("SerializationException: ${exception.message}")
+                    throw PrintMessage(
+                        "SerializationException: ${exception.message}",
+                        statusCode = 1,
+                        printError = true
+                    )
                 }
             }
 

--- a/src/nativeMain/kotlin/dev/sriniketh/UnixTimeCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/UnixTimeCommand.kt
@@ -2,6 +2,7 @@ package dev.sriniketh
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.PrintMessage
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.groupChoice
 import com.github.ajalt.clikt.parameters.options.option
@@ -41,13 +42,21 @@ internal class UnixTimeCommand(private val clock: Clock = Clock.System) : CliktC
             is MillisToISO -> try {
                 echo(timeInMillisToIso8601(it.timeInMillis.toLong()))
             } catch (_: NumberFormatException) {
-                echo("Number format exception: invalid input ${it.timeInMillis}")
+                throw PrintMessage(
+                    "Number format exception: invalid input ${it.timeInMillis}",
+                    statusCode = 1,
+                    printError = true
+                )
             }
 
             is ISOToMillis -> try {
                 echo(iso8601ToTimeInMillis(it.timeInISO))
             } catch (_: IllegalArgumentException) {
-                echo("Illegal argument exception: invalid input ${it.timeInISO}")
+                throw PrintMessage(
+                    "Illegal argument exception: invalid input ${it.timeInISO}",
+                    statusCode = 1,
+                    printError = true
+                )
             }
 
             else -> echo("Invalid operation")

--- a/src/nativeTest/kotlin/dev.sriniketh/DecodingCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/DecodingCommandTest.kt
@@ -54,8 +54,8 @@ class DecodingCommandTest {
     @Test
     fun `decode utf8 prints error for invalid hex input`() {
         val result = decodingCommand.test("""utf8 --string="ZZZZ"""")
-        assertEquals(0, result.statusCode)
-        assertContains(result.stdout, "Invalid UTF-8 hex input:")
+        assertNotEquals(0, result.statusCode)
+        assertContains(result.stderr, "Invalid UTF-8 hex input:")
     }
 
     // base64
@@ -72,7 +72,7 @@ class DecodingCommandTest {
     @Test
     fun `decode base64 prints error for invalid base64 input`() {
         val result = decodingCommand.test("""base64 --string="!!invalid!!" """)
-        assertEquals(0, result.statusCode)
-        assertContains(result.stdout, "Invalid base64 input:")
+        assertNotEquals(0, result.statusCode)
+        assertContains(result.stderr, "Invalid base64 input:")
     }
 }

--- a/src/nativeTest/kotlin/dev.sriniketh/HashCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/HashCommandTest.kt
@@ -55,7 +55,8 @@ class HashCommandTest {
     @Test
     fun `hash md5 prints exception when file input is invalid`() {
         val result = hashCommand.test("md5 --file=HashingTestFiles.txt")
-        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stdout.removeNewLines())
+        assertNotEquals(0, result.statusCode)
+        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stderr.removeNewLines())
     }
 
     @Test
@@ -87,7 +88,8 @@ class HashCommandTest {
     @Test
     fun `hash sha256 prints exception when file input is invalid`() {
         val result = hashCommand.test("sha256 --file=HashingTestFiles.txt")
-        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stdout.removeNewLines())
+        assertNotEquals(0, result.statusCode)
+        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stderr.removeNewLines())
     }
 
     @Test
@@ -125,7 +127,8 @@ class HashCommandTest {
     @Test
     fun `hash sha512 prints exception when file input is invalid`() {
         val result = hashCommand.test("sha512 --file=HashingTestFiles.txt")
-        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stdout.removeNewLines())
+        assertNotEquals(0, result.statusCode)
+        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stderr.removeNewLines())
     }
 
     @Test
@@ -163,7 +166,8 @@ class HashCommandTest {
     @Test
     fun `hash sha1 prints exception when file input is invalid`() {
         val result = hashCommand.test("sha1 --file=HashingTestFiles.txt")
-        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stdout.removeNewLines())
+        assertNotEquals(0, result.statusCode)
+        assertEquals("IOException: no such file: HashingTestFiles.txt", result.stderr.removeNewLines())
     }
 
     @Test

--- a/src/nativeTest/kotlin/dev.sriniketh/PrettyPrintCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/PrettyPrintCommandTest.kt
@@ -67,14 +67,14 @@ class PrettyPrintCommandTest {
     fun `prettyprint throws exception for invalid json`() {
         val result =
             prettyPrintCommand.test("""json --string="{\"a\":42, \"b\": \"something\", \"c\": {\"d\":43, \""""")
+        assertNotEquals(0, result.statusCode)
         assertEquals(
             """
-
                 IllegalArgumentException: Unexpected JSON token at offset 42: EOF at path: $
                 JSON input: {"a":42, "b": "something", "c": {"d":43, "
 
             """.trimIndent(),
-            result.stdout
+            result.stderr
         )
     }
 

--- a/src/nativeTest/kotlin/dev.sriniketh/UnixTimeCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/UnixTimeCommandTest.kt
@@ -5,6 +5,7 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 
 class UnixTimeCommandTest {
 
@@ -50,9 +51,10 @@ class UnixTimeCommandTest {
     @Test
     fun `test unixtime --operation=millistoiso throws exception when ISO string passed is invalid`() {
         val result = unixTimeCommand.test("--operation=millistoiso --millis=abcdef")
+        assertNotEquals(0, result.statusCode)
         assertEquals(
             "Number format exception: invalid input abcdef",
-            result.stdout.removeNewLines()
+            result.stderr.removeNewLines()
         )
     }
 
@@ -71,9 +73,10 @@ class UnixTimeCommandTest {
     @Test
     fun `test unixtime --operation=isotomillis throws exception when ISO string passed is invalid`() {
         val result = unixTimeCommand.test("--operation=isotomillis --iso=2023-11-30T08:02:33.006S")
+        assertNotEquals(0, result.statusCode)
         assertEquals(
             "Illegal argument exception: invalid input 2023-11-30T08:02:33.006S",
-            result.stdout.removeNewLines()
+            result.stderr.removeNewLines()
         )
     }
 


### PR DESCRIPTION
## Summary

This is an intentional **breaking CLI contract change**. Previously every subcommand (`decode`, `hash`, `prettyprint`, `unixtime`) printed runtime errors (invalid hex/base64, missing/unreadable file, bad timestamp, malformed JSON) to **stdout** via `echo(...)` and then returned normally, so the process always exited `0` — even on failure.

Consequences of the old behavior:
- `ktools hash sha256 -f missing && deploy` would proceed as if hashing succeeded.
- `ktools decode base64 -s "$x" | consumer` would feed the error text downstream as if it were real data.

Fix: each error branch now throws `PrintMessage(message, statusCode = 1, printError = true)`, which routes the message to **stderr** and exits with a **non-zero** status code. Success-path output is untouched — it still goes to stdout with exit code 0.

Call sites changed:
- `DecodingCommand.kt`: invalid UTF-8 hex input, invalid base64 input.
- `HashCommand.kt`: `IOException` in `printHashForFileOrExceptionIfFailure` (missing/unreadable file).
- `PrettyPrintCommand.kt`: invalid JSON (`IllegalArgumentException` and `SerializationException` catches).
- `UnixTimeCommand.kt`: invalid millis (`NumberFormatException`), invalid ISO string (`IllegalArgumentException`).

Now scripts can reliably detect failures via exit code, and piped stdout is no longer polluted with error text.

## Test plan

- Updated `DecodingCommandTest.kt`, `HashCommandTest.kt`, `PrettyPrintCommandTest.kt`, `UnixTimeCommandTest.kt`: assertions that previously expected `statusCode == 0` on error paths now assert non-zero, and error-message assertions now check `result.stderr` instead of `result.stdout`.
- `./gradlew allTests` passes.
- `./gradlew build` passes (compiles cleanly for all native targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)