### PR TITLE
fix(build): wire detekt into check so it actually gates CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -117,6 +117,21 @@ tasks.withType<Detekt>().configureEach {
     }
 }
 
+// In this KMP project the base `detekt` lifecycle task has no sources of its own; the actual
+// analysis happens in target-specific tasks (e.g. `detektMetadataCommonMain`, `detektMacosArm64Main`).
+// Those aren't wired into `check` by default, so `./gradlew build` never actually gated on them.
+// Wire every source-bearing detekt task into `check` so `build`/CI enforces them.
+tasks.named("check") {
+    dependsOn(
+        tasks.matching {
+            it.name.startsWith("detekt") &&
+                !it.name.startsWith("detektBaseline") &&
+                it.name != "detektGenerateConfig" &&
+                it.name != "detekt"
+        }
+    )
+}
+
 // gradle versions plugin config
 tasks.named<DependencyUpdatesTask>("dependencyUpdates") {
     checkForGradleUpdate = true

--- a/src/nativeMain/kotlin/dev/sriniketh/AboutOption.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/AboutOption.kt
@@ -15,7 +15,10 @@ internal fun <T : CliktCommand> T.aboutOption(): T =
         val librariesAndLicenses = json.decodeFromString<LibrariesAndLicenses>(BuildConfig.ABOUT_LIBRARIES_JSON)
 
         val stringBuilder = StringBuilder().apply {
-            appendLine("ktools is a command line application that provides useful developer tools. It's built as a kotlin multiplatform project.")
+            appendLine(
+                "ktools is a command line application that provides useful developer tools. " +
+                    "It's built as a kotlin multiplatform project."
+            )
             appendLine("Learn more at https://github.com/sriniketh/ktools.")
 
             appendLine()

--- a/src/nativeMain/kotlin/dev/sriniketh/UUIDCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/UUIDCommand.kt
@@ -7,19 +7,19 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.types.enum
 
 internal class UUIDCommand : CliktCommand(name = "uuid") {
-    private enum class Case { lower, upper }
+    private enum class Case { LOWER, UPPER }
 
     private val case by option("-c", "--case", help = "Use upper or lower case. Default is lower.")
-        .enum<Case>()
-        .default(Case.lower)
+        .enum<Case> { it.name.lowercase() }
+        .default(Case.LOWER)
 
     override fun help(context: Context): String = "Create a random UUID"
 
     override fun run() {
         val uuid = createRandomUUID()
         when (case) {
-            Case.lower -> echo(uuid.lowercase())
-            Case.upper -> echo(uuid.uppercase())
+            Case.LOWER -> echo(uuid.lowercase())
+            Case.UPPER -> echo(uuid.uppercase())
         }
     }
 }


### PR DESCRIPTION
## Summary
- Detekt was applied with `maxIssues: 0` but the KMP source-bearing tasks (`detektMetadataCommonMain`, `detektMacosArm64Main`, etc.) were never attached to `check`, so `./gradlew build`/CI never actually gated on detekt findings.
- Wires every source-bearing `detekt*` task (excluding `detektBaseline*`, `detektGenerateConfig`, and the empty base `detekt` task) into `check`, so `build`/CI now picks it up with no workflow changes.
- Fixes the two real, pre-existing violations this surfaced:
  - `src/nativeMain/kotlin/dev/sriniketh/AboutOption.kt`: a 146-char string literal violating `MaxLineLength` (120) — split across two concatenated string parts, `--about` output text is unchanged.
  - `src/nativeMain/kotlin/dev/sriniketh/UUIDCommand.kt`: enum entries `lower`/`upper` violating `EnumNaming` — renamed to `LOWER`/`UPPER` with an explicit `key` selector on `.enum<Case>()` so the CLI-facing behavior (`--case=(lower|upper)` help text and accepted values) is unchanged.

## Test plan
- Ran `./gradlew build` locally — confirmed the detekt tasks (`detektMetadataCommonMain`, `detektMetadataNativeMain`, `detektMacosArm64Main`, `detektMacosArm64Test`, `detektMacosX64Main`, `detektMacosX64Test`, `detektLinuxX64Main`, `detektLinuxX64Test`, `detektMingwX64Main`, `detektMingwX64Test`, plus the intermediate metadata tasks) now execute as part of `check`, and the build passes with zero detekt issues.
- Verified `--about` output is byte-for-byte identical before/after.
- Verified `uuid --help` and `uuid -c lower|upper` output is identical before/after the enum rename.