### PR TITLE
fix(build): add distributionSha256Sum to gradle wrapper properties

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 retries=0


### PR DESCRIPTION
## Summary
- Adds `distributionSha256Sum` to `gradle/wrapper/gradle-wrapper.properties`, pinning the exact SHA-256 of the `gradle-9.6.1-bin.zip` distribution currently referenced by `distributionUrl`.
- Closes CODEBASE_REVIEW.md §1.2 (Medium): without this, `validate-wrappers: true` (already enabled in CI via a prior PR) has no known-good hash to validate the downloaded Gradle distribution against, so a swapped/tampered distribution would go undetected.
- Renovate will keep this hash current on future Gradle version bumps (it already tracks `distributionUrl`).

## Test plan
- [x] Verified the committed hash matches `https://services.gradle.org/distributions/gradle-9.6.1-bin.zip.sha256` exactly (independently re-fetched during review).
- [x] `./gradlew --version` succeeds locally with the new checksum in place (a mismatch would fail immediately).

Reviewed via subagent-driven-development: implementer + independent reviewer both verified spec compliance and correctness. No findings.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>