### PR TITLE
fix(prettyprint): route json parse errors through the catch that actually fires

### DIFF
--- a/src/commonMain/kotlin/dev/sriniketh/PrettyPrint.kt
+++ b/src/commonMain/kotlin/dev/sriniketh/PrettyPrint.kt
@@ -10,10 +10,9 @@ import kotlinx.serialization.json.JsonElement
  *
  * @param[jsonString] JSON string that needs to be formatted.
  * @return Formatted json string.
- * @throws IllegalArgumentException
  * @throws SerializationException
  */
-@Throws(IllegalArgumentException::class, SerializationException::class)
+@Throws(SerializationException::class)
 fun prettyPrintJson(jsonString: String): String {
     val prettyJson = Json { prettyPrint = true }
     val jsonElement = prettyJson.decodeFromString<JsonElement>(jsonString)

--- a/src/nativeMain/kotlin/dev/sriniketh/PrettyPrintCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/PrettyPrintCommand.kt
@@ -31,10 +31,8 @@ internal class PrettyPrintCommand : CliktCommand(name = "prettyprint") {
                 try {
                     echo()
                     echo(prettyPrintJson(content))
-                } catch (exception: IllegalArgumentException) {
-                    echo("IllegalArgumentException: ${exception.message}")
                 } catch (exception: SerializationException) {
-                    echo("SerializationException: ${exception.message}")
+                    echo("Invalid JSON: ${exception.message}")
                 }
             }
 

--- a/src/nativeTest/kotlin/dev.sriniketh/PrettyPrintCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/PrettyPrintCommandTest.kt
@@ -70,7 +70,7 @@ class PrettyPrintCommandTest {
         assertEquals(
             """
 
-                IllegalArgumentException: Unexpected JSON token at offset 42: EOF at path: $
+                Invalid JSON: Unexpected JSON token at offset 42: EOF at path: $
                 JSON input: {"a":42, "b": "something", "c": {"d":43, "
 
             """.trimIndent(),


### PR DESCRIPTION
## Summary
- `PrettyPrintCommand.kt`'s json branch caught `IllegalArgumentException` before `SerializationException` — since `SerializationException` IS-A `IllegalArgumentException`, the second catch was unreachable dead code, proven by the existing test printing the class-name-leaking `"IllegalArgumentException: Unexpected JSON token…"` message.
- Removes the dead catch (verified `prettyPrintJson`'s only two calls, `decodeFromString`/`encodeToString`, can only ever raise `SerializationException` — traced through kotlinx.serialization 1.11.0 source), and prints a human-readable `"Invalid JSON: …"` message instead.
- Simplifies the now-redundant `@Throws(IllegalArgumentException::class, SerializationException::class)` on `prettyPrintJson` to `@Throws(SerializationException::class)`.
- Closes CODEBASE_REVIEW.md §2.2 (Medium). Scoped strictly to the `json` branch — the `cookie-header` branch (§1.4) and the stdout/exit-code contract (§2.1) are untouched, both being handled in separate PRs.

## Test plan
- [x] `./gradlew allTests` passes, including the updated `PrettyPrintCommandTest`.
- [x] Independently verified in review that a single `SerializationException` catch is correct by tracing kotlinx.serialization's `JsonTreeReader`/`StreamingJsonDecoder` source — no other exception type can reach this call site.

Reviewed via subagent-driven-development: implementer + independent reviewer, no findings.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>