### PR TITLE
fix(release): attest build provenance and ship SHA256SUMS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ permissions:
 jobs:
   build_macosArm:
     runs-on: macos-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -26,6 +29,10 @@ jobs:
           validate-wrappers: true
       - name: Build with Gradle
         run: ./gradlew macosArm64Binaries
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: build/bin/macosArm64/releaseExecutable/ktools.kexe
       - name: Upload macos Arm build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -34,6 +41,9 @@ jobs:
 
   build_macosX64:
     runs-on: macos-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -49,6 +59,10 @@ jobs:
           validate-wrappers: true
       - name: Build with Gradle
         run: ./gradlew macosX64Binaries
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: build/bin/macosX64/releaseExecutable/ktools.kexe
       - name: Upload macos X64 build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -57,6 +71,9 @@ jobs:
 
   build_linuxX64:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -72,6 +89,10 @@ jobs:
           validate-wrappers: true
       - name: Build with Gradle
         run: ./gradlew linuxX64Binaries
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: build/bin/linuxX64/releaseExecutable/ktools.kexe
       - name: Upload linux X64 build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -80,6 +101,9 @@ jobs:
 
   build_windowsX64:
     runs-on: windows-latest
+    permissions:
+      id-token: write
+      attestations: write
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
@@ -95,6 +119,10 @@ jobs:
           validate-wrappers: true
       - name: Build with Gradle
         run: ./gradlew mingwX64Binaries
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2
+        with:
+          subject-path: build/bin/mingwX64/releaseExecutable/ktools.exe
       - name: Upload windows X64 build
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
@@ -121,6 +149,9 @@ jobs:
           mv build/macos-x64-build/ktools.kexe build/macos-x64-build/macos-x64-ktools.kexe
           mv build/linux-x64-build/ktools.kexe build/linux-x64-build/linux-x64-ktools.kexe
           mv build/windows-x64-build/ktools.exe build/windows-x64-build/windows-x64-ktools.exe
+      - name: Generate SHA256SUMS
+        working-directory: build
+        run: sha256sum */*.kexe */*.exe > SHA256SUMS
       - name: Make Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:
@@ -129,3 +160,4 @@ jobs:
             build/macos-x64-build/macos-x64-ktools.kexe
             build/linux-x64-build/linux-x64-ktools.kexe
             build/windows-x64-build/windows-x64-ktools.exe
+            build/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   build_macosArm:
     runs-on: macos-latest
     permissions:
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -42,6 +43,7 @@ jobs:
   build_macosX64:
     runs-on: macos-latest
     permissions:
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -72,6 +74,7 @@ jobs:
   build_linuxX64:
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -102,6 +105,7 @@ jobs:
   build_windowsX64:
     runs-on: windows-latest
     permissions:
+      contents: read
       id-token: write
       attestations: write
     steps:
@@ -151,7 +155,14 @@ jobs:
           mv build/windows-x64-build/ktools.exe build/windows-x64-build/windows-x64-ktools.exe
       - name: Generate SHA256SUMS
         working-directory: build
-        run: sha256sum */*.kexe */*.exe > SHA256SUMS
+        run: |
+          mkdir -p flat
+          cp macos-arm-build/macos-arm-ktools.kexe flat/
+          cp macos-x64-build/macos-x64-ktools.kexe flat/
+          cp linux-x64-build/linux-x64-ktools.kexe flat/
+          cp windows-x64-build/windows-x64-ktools.exe flat/
+          (cd flat && sha256sum * > ../SHA256SUMS)
+          rm -rf flat
       - name: Make Release
         uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3
         with:


### PR DESCRIPTION
## Summary
- Adds `actions/attest-build-provenance` (SHA-pinned to v2) to all 4 release build jobs, generating SLSA build provenance for each binary right after it's built and before upload, so `gh attestation verify <binary> --repo sriniketh/ktools` works post-release.
- Adds `id-token: write` + `attestations: write` (plus explicit `contents: read`, since job-level `permissions:` overrides rather than merges with the workflow-level default) to each of those 4 jobs.
- Generates a `SHA256SUMS` file covering all 4 release binaries and attaches it to the release alongside the binaries. Checksums are computed against a flattened, basename-only view of the binaries so `sha256sum -c SHA256SUMS` works correctly against what a user actually downloads from the release page (verified end-to-end in review).
- Closes CODEBASE_REVIEW.md §1.3 (Medium) and executes the intent of the previously-drafted (untracked) `docs/superpowers/plans/2026-04-17-binary-attestation.md`, adapted to the workflow's current SHA-pinned/setup-gradle form.

## Test plan
- [x] YAML validated.
- [x] `attest-build-provenance@v2` SHA independently re-verified against `gh api repos/actions/attest-build-provenance/commits/v2`.
- [x] Each job's `subject-path` cross-checked against its own binary output path (no cross-job copy/paste errors).
- [x] Reproduced the real download scenario locally: staged the 4 renamed binaries flat, ran `sha256sum -c SHA256SUMS` against the generated file — all 4 verify OK.
- [ ] Can't fully execute this workflow locally (release-tag-triggered) — should be watched on the next tagged release.

Reviewed via subagent-driven-development with one fix-and-re-review cycle (an initial review found the SHA256SUMS paths weren't usable against flat downloaded files; fixed and re-verified).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>