### PR TITLE
perf(gradle): enable configuration cache, build cache, and parallelism

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 kotlin.code.style=official
-org.gradle.jvmargs=-Xmx1024m
-#Disable compiler cache for linuxX64
-kotlin.native.cacheKind.linuxX64=none
+org.gradle.jvmargs=-Xmx4096m
+org.gradle.configuration-cache=true
+org.gradle.caching=true
+org.gradle.parallel=true


### PR DESCRIPTION
## Summary
- Enables `org.gradle.configuration-cache`, `org.gradle.caching`, and `org.gradle.parallel` in `gradle.properties`.
- Raises the JVM heap from `-Xmx1024m` to `-Xmx4096m` (more appropriate for a multi-target Kotlin/Native build).
- Removes `kotlin.native.cacheKind.linuxX64=none` — independently re-verified (clean build, `--no-build-cache --rerun`) that cross-compiling linuxX64 from macOS works fine without it on the current Kotlin version; the workaround's original justification no longer applies.
- Closes CODEBASE_REVIEW.md §5.3 (Medium).

## Test plan
- [x] `./gradlew build` succeeds across all targets.
- [x] Configuration cache confirmed working: "Configuration cache entry stored" then "Configuration cache entry reused" across two runs, no incompatibility warnings.
- [x] Build cache confirmed working: `FROM-CACHE` task outcomes on a clean rebuild.
- [x] linuxX64 verified independently from scratch (`./gradlew clean && ./gradlew linuxX64Binaries --no-build-cache --rerun`) without the removed cacheKind flag — succeeds.

Reviewed via subagent-driven-development: implementer + independent reviewer, both re-verified build/cache behavior first-hand rather than trusting reports. No findings.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>