### PR TITLE
fix(unixtime): require --operation and drop the unreachable else branch

### DIFF
--- a/src/nativeMain/kotlin/dev/sriniketh/UnixTimeCommand.kt
+++ b/src/nativeMain/kotlin/dev/sriniketh/UnixTimeCommand.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.groupChoice
+import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.prompt
 import kotlin.time.Clock
@@ -30,7 +31,7 @@ internal class UnixTimeCommand(private val clock: Clock = Clock.System) : CliktC
         "nowiso" to NowISO(),
         "millistoiso" to MillisToISO(),
         "isotomillis" to ISOToMillis(),
-    )
+    ).required()
 
     override fun help(context: Context): String = "Unix time conversions"
 
@@ -49,8 +50,6 @@ internal class UnixTimeCommand(private val clock: Clock = Clock.System) : CliktC
             } catch (_: IllegalArgumentException) {
                 echo("Illegal argument exception: invalid input ${it.timeInISO}")
             }
-
-            else -> echo("Invalid operation")
         }
     }
 }

--- a/src/nativeTest/kotlin/dev.sriniketh/UnixTimeCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/UnixTimeCommandTest.kt
@@ -77,6 +77,12 @@ class UnixTimeCommandTest {
         )
     }
 
+    @Test
+    fun `test unixtime with no --operation flag exits with non-zero status code`() {
+        val result = unixTimeCommand.test("")
+        assertEquals(1, result.statusCode)
+    }
+
     private class FakeClock : Clock {
         override fun now(): Instant = Instant.fromEpochMilliseconds(1701331353006)
     }

--- a/src/nativeTest/kotlin/dev.sriniketh/UnixTimeCommandTest.kt
+++ b/src/nativeTest/kotlin/dev.sriniketh/UnixTimeCommandTest.kt
@@ -4,6 +4,7 @@ import com.github.ajalt.clikt.testing.test
 import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class UnixTimeCommandTest {
@@ -81,6 +82,7 @@ class UnixTimeCommandTest {
     fun `test unixtime with no --operation flag exits with non-zero status code`() {
         val result = unixTimeCommand.test("")
         assertEquals(1, result.statusCode)
+        assertContains(result.stderr, "missing option --operation")
     }
 
     private class FakeClock : Clock {


### PR DESCRIPTION
## Summary
- `UnixTimeCommand`'s `operation` was built via `.groupChoice(...)` without `.required()`, so omitting `-o`/`--operation` silently hit an `else -> echo("Invalid operation")` branch with exit code 0 — misleading text and a success exit code for what's actually a missing required argument, and inconsistent with every other subcommand.
- Adds `.required()`; the `when` over the sealed `Operation` class is now exhaustive, so the dead `else` branch is removed entirely.
- Closes CODEBASE_REVIEW.md §2.3 (Medium). Scoped strictly to the `operation` selector — the two untouched catch blocks (millis/ISO parse errors, governed by §2.1 elsewhere) are unchanged.

## Test plan
- [x] New test confirms omitting `--operation` now exits 1 with Clikt's genuine `Error: missing option --operation` on stderr (independently verified in review via a throwaway diagnostic, then the assertion was strengthened to check stderr content, not just the exit code).
- [x] `./gradlew allTests` passes, including all 4 existing operation tests, unchanged.

Reviewed via subagent-driven-development: implementer + independent reviewer. Reviewer flagged one Minor gap (assertion only checked exit code, not message content) — addressed before merge.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>