### PR TITLE
docs: fix stale commands.md, wire aboutlibraries freshness, unpublish internal plans

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -100,6 +100,29 @@ buildConfig {
     )
 }
 
+// Keep the checked-in aboutlibraries export current: every generated BuildConfig embeds
+// `librariesandlicenses.json` as a string (see `ABOUT_LIBRARIES_JSON` above), read lazily at task
+// execution time. Without this, the JSON only gets refreshed when someone remembers to run
+// `exportLibraryDefinitions` by hand after a dependency bump, so the shipped `--about` output
+// silently drifts from the real version catalog. `exportLibraryDefinitions` only reads metadata
+// (POMs) already fetched during normal dependency resolution, so it's safe and network-free to run
+// on every build - wiring it as a task dependency (rather than a separate CI freshness check) means
+// `./gradlew build` regenerates the JSON automatically and it can never go stale again.
+tasks.matching {
+    it.name.startsWith("generate") && it.name.endsWith("BuildConfigClasses")
+}.configureEach {
+    dependsOn("exportLibraryDefinitions")
+}
+
+// exportLibraryDefinitions writes into src/nativeMain/resources, which every *ProcessResources
+// task for a native/metadata target also reads from when packaging that source set's resources.
+// Now that exportLibraryDefinitions runs as part of a normal build (wired in above), Gradle's task
+// validation flags that overlap as an undeclared implicit dependency unless we tell it those tasks
+// must run after the export - otherwise output could be produced in the wrong order.
+tasks.matching { it.name.endsWith("ProcessResources") }.configureEach {
+    mustRunAfter("exportLibraryDefinitions")
+}
+
 // detekt plugin config
 detekt {
     buildUponDefaultConfig = true

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,7 +1,7 @@
 # Commands
 
 ## ktools --help
-```dtd
+```text
 Usage: ktools [<options>] <command> [<args>]...
 
 Options:
@@ -19,40 +19,41 @@ Commands:
 ```
 
 ## ktools --version
-```dtd
-ktools version 0.1.0
+```text
+ktools version v0.4.0-20-g8087ca6
 ```
 
 ## ktools --about
-```dtd
+```text
 ktools is a command line application that provides useful developer tools. It's built as a kotlin multiplatform project.
 Learn more at https://github.com/sriniketh/ktools.
 
 Libraries used:
-Clikt : com.github.ajalt.clikt:clikt : 5.0.3
-Clikt Core : com.github.ajalt.clikt:clikt-core : 5.0.3
+Clikt : com.github.ajalt.clikt:clikt : 5.1.0
+Clikt Core : com.github.ajalt.clikt:clikt-core : 5.1.0
 Colormath : com.github.ajalt.colormath:colormath : 3.6.0
-Mordant : com.github.ajalt.mordant:mordant : 3.0.1
-Mordant Core : com.github.ajalt.mordant:mordant-core : 3.0.1
-okio : com.squareup.okio:okio : 3.10.2
-ktor-client-core : io.ktor:ktor-client-core : 3.1.1
-ktor-events : io.ktor:ktor-events : 3.1.1
-ktor-http : io.ktor:ktor-http : 3.1.1
-ktor-http-cio : io.ktor:ktor-http-cio : 3.1.1
-ktor-io : io.ktor:ktor-io : 3.1.1
-ktor-serialization : io.ktor:ktor-serialization : 3.1.1
-ktor-sse : io.ktor:ktor-sse : 3.1.1
-ktor-utils : io.ktor:ktor-utils : 3.1.1
-ktor-websocket-serialization : io.ktor:ktor-websocket-serialization : 3.1.1
-ktor-websockets : io.ktor:ktor-websockets : 3.1.1
-Kotlin Stdlib : org.jetbrains.kotlin:kotlin-stdlib : 2.1.10
+Mordant : com.github.ajalt.mordant:mordant : 3.0.2
+Mordant Core : com.github.ajalt.mordant:mordant-core : 3.0.2
+okio : com.squareup.okio:okio : 3.17.0
+ktor-client-core : io.ktor:ktor-client-core : 3.5.1
+ktor-events : io.ktor:ktor-events : 3.5.1
+ktor-http : io.ktor:ktor-http : 3.5.1
+ktor-http-cio : io.ktor:ktor-http-cio : 3.5.1
+ktor-io : io.ktor:ktor-io : 3.5.1
+ktor-serialization : io.ktor:ktor-serialization : 3.5.1
+ktor-sse : io.ktor:ktor-sse : 3.5.1
+ktor-utils : io.ktor:ktor-utils : 3.5.1
+ktor-websocket-serialization : io.ktor:ktor-websocket-serialization : 3.5.1
+ktor-websockets : io.ktor:ktor-websockets : 3.5.1
+Kotlin Stdlib : org.jetbrains.kotlin:kotlin-stdlib : 2.3.21
+Kotlin Stdlib Common : org.jetbrains.kotlin:kotlin-stdlib-common : 2.3.21
 atomicfu : org.jetbrains.kotlinx:atomicfu : 0.23.1
-kotlinx-coroutines-core : org.jetbrains.kotlinx:kotlinx-coroutines-core : 1.10.1
-kotlinx-datetime : org.jetbrains.kotlinx:kotlinx-datetime : 0.6.2
-kotlinx-io-bytestring : org.jetbrains.kotlinx:kotlinx-io-bytestring : 0.6.0
-kotlinx-io-core : org.jetbrains.kotlinx:kotlinx-io-core : 0.6.0
-kotlinx-serialization-core : org.jetbrains.kotlinx:kotlinx-serialization-core : 1.8.0
-kotlinx-serialization-json : org.jetbrains.kotlinx:kotlinx-serialization-json : 1.8.0
+kotlinx-coroutines-core : org.jetbrains.kotlinx:kotlinx-coroutines-core : 1.11.0
+kotlinx-datetime : org.jetbrains.kotlinx:kotlinx-datetime : 0.8.0-0.6.x-compat
+kotlinx-io-bytestring : org.jetbrains.kotlinx:kotlinx-io-bytestring : 0.9.0
+kotlinx-io-core : org.jetbrains.kotlinx:kotlinx-io-core : 0.9.0
+kotlinx-serialization-core : org.jetbrains.kotlinx:kotlinx-serialization-core : 1.11.0
+kotlinx-serialization-json : org.jetbrains.kotlinx:kotlinx-serialization-json : 1.11.0
 
 Licenses:
 Apache-2.0 : Apache License 2.0 : https://spdx.org/licenses/Apache-2.0.html
@@ -60,7 +61,7 @@ MIT : MIT License : https://spdx.org/licenses/MIT.html
 ```
 
 ## ktools uuid
-```dtd
+```text
 Usage: ktools uuid [<options>]
 
   Create a random UUID
@@ -71,7 +72,7 @@ Options:
 ```
 
 ## ktools unixtime
-```dtd
+```text
 Usage: ktools unixtime [<options>]
 
   Unix time conversions
@@ -83,12 +84,14 @@ Convert time in ISO 8601 format to millis:
   --iso=<text>
 
 Options:
-  -o, --operation=(nowmillis|nowiso|millistoiso|isotomillis)  Choose operation to perform: [nowmillis | nowiso | millistoiso | isotomillis]
-  -h, --help                                                  Show this message and exit
+  -o, --operation=(nowmillis|nowiso|millistoiso|isotomillis)
+              Choose operation to perform: [nowmillis | nowiso | millistoiso |
+              isotomillis]
+  -h, --help  Show this message and exit
 ```
 
 ## ktools hash
-```dtd
+```text
 Usage: ktools hash [<options>] <algorithm>
 
   Get hash value for given file or string
@@ -103,7 +106,7 @@ Arguments:
 ```
 
 ## ktools encode
-```dtd
+```text
 Usage: ktools encode [<options>] <format>
 
   Encode text content
@@ -117,7 +120,7 @@ Arguments:
 ```
 
 ## ktools decode
-```dtd
+```text
 Usage: ktools decode [<options>] <format>
 
   Decode text content
@@ -131,7 +134,7 @@ Arguments:
 ```
 
 ## ktools prettyprint
-```dtd
+```text
 Usage: ktools prettyprint [<options>] <contenttype>
 
   Pretty print content

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,12 @@ nav:
   - 'Commands': commands.md
   - 'Docs': dokka/ktools/dev.sriniketh/index.html
 
+# Internal planning docs live under docs/superpowers/ so they're easy to find locally, but they're
+# not part of the published site (they're absent from `nav` above) and `mkdocs gh-deploy` would
+# otherwise still copy and publish them since they sit under `docs_dir`. Exclude them explicitly.
+exclude_docs: |
+  superpowers/
+
 extra:
   social:
     - icon: fontawesome/brands/github-alt

--- a/src/nativeMain/resources/librariesandlicenses.json
+++ b/src/nativeMain/resources/librariesandlicenses.json
@@ -2,581 +2,581 @@
     "libraries": [
         {
             "uniqueId": "com.github.ajalt.clikt:clikt",
-            "funding": [
-                
-            ],
+            "artifactVersion": "5.1.0",
+            "name": "Clikt",
+            "description": "Multiplatform command line interface parsing for Kotlin",
+            "website": "https://github.com/ajalt/clikt/",
             "developers": [
                 {
                     "name": "AJ Alt"
                 }
             ],
-            "artifactVersion": "5.1.0",
-            "description": "Multiplatform command line interface parsing for Kotlin",
             "scm": {
                 "connection": "scm:git:git://github.com/ajalt/clikt.git",
-                "url": "https://github.com/ajalt/clikt/",
-                "developerConnection": "scm:git:ssh://git@github.com/ajalt/clikt.git"
+                "developerConnection": "scm:git:ssh://git@github.com/ajalt/clikt.git",
+                "url": "https://github.com/ajalt/clikt/"
             },
-            "name": "Clikt",
-            "website": "https://github.com/ajalt/clikt/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "com.github.ajalt.clikt:clikt-core",
-            "funding": [
-                
-            ],
+            "artifactVersion": "5.1.0",
+            "name": "Clikt Core",
+            "description": "Multiplatform command line interface parsing for Kotlin",
+            "website": "https://github.com/ajalt/clikt/",
             "developers": [
                 {
                     "name": "AJ Alt"
                 }
             ],
-            "artifactVersion": "5.1.0",
-            "description": "Multiplatform command line interface parsing for Kotlin",
             "scm": {
                 "connection": "scm:git:git://github.com/ajalt/clikt.git",
-                "url": "https://github.com/ajalt/clikt/",
-                "developerConnection": "scm:git:ssh://git@github.com/ajalt/clikt.git"
+                "developerConnection": "scm:git:ssh://git@github.com/ajalt/clikt.git",
+                "url": "https://github.com/ajalt/clikt/"
             },
-            "name": "Clikt Core",
-            "website": "https://github.com/ajalt/clikt/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "com.github.ajalt.colormath:colormath",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.6.0",
+            "name": "Colormath",
+            "description": "Multiplatform color space conversions for Kotlin",
+            "website": "https://github.com/ajalt/colormath/",
             "developers": [
                 {
                     "name": "AJ Alt"
                 }
             ],
-            "artifactVersion": "3.6.0",
-            "description": "Multiplatform color space conversions for Kotlin",
             "scm": {
                 "connection": "scm:git:git://github.com/ajalt/colormath.git",
-                "url": "https://github.com/ajalt/colormath/",
-                "developerConnection": "scm:git:ssh://git@github.com/ajalt/colormath.git"
+                "developerConnection": "scm:git:ssh://git@github.com/ajalt/colormath.git",
+                "url": "https://github.com/ajalt/colormath/"
             },
-            "name": "Colormath",
-            "website": "https://github.com/ajalt/colormath/",
             "licenses": [
                 "MIT"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "com.github.ajalt.mordant:mordant",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.0.2",
+            "name": "Mordant",
+            "description": "Colorful multiplatform styling Kotlin for command-line applications",
+            "website": "https://github.com/ajalt/mordant/",
             "developers": [
                 {
                     "name": "AJ Alt"
                 }
             ],
-            "artifactVersion": "3.0.2",
-            "description": "Colorful multiplatform styling Kotlin for command-line applications",
             "scm": {
                 "connection": "scm:git:git://github.com/ajalt/mordant.git",
-                "url": "https://github.com/ajalt/",
-                "developerConnection": "scm:git:ssh://git@github.com/ajalt/mordant.git"
+                "developerConnection": "scm:git:ssh://git@github.com/ajalt/mordant.git",
+                "url": "https://github.com/ajalt/"
             },
-            "name": "Mordant",
-            "website": "https://github.com/ajalt/mordant/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "com.github.ajalt.mordant:mordant-core",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.0.2",
+            "name": "Mordant Core",
+            "description": "Colorful multiplatform styling Kotlin for command-line applications",
+            "website": "https://github.com/ajalt/mordant/",
             "developers": [
                 {
                     "name": "AJ Alt"
                 }
             ],
-            "artifactVersion": "3.0.2",
-            "description": "Colorful multiplatform styling Kotlin for command-line applications",
             "scm": {
                 "connection": "scm:git:git://github.com/ajalt/mordant.git",
-                "url": "https://github.com/ajalt/",
-                "developerConnection": "scm:git:ssh://git@github.com/ajalt/mordant.git"
+                "developerConnection": "scm:git:ssh://git@github.com/ajalt/mordant.git",
+                "url": "https://github.com/ajalt/"
             },
-            "name": "Mordant Core",
-            "website": "https://github.com/ajalt/mordant/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "com.squareup.okio:okio",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.17.0",
+            "name": "okio",
+            "description": "A modern I/O library for Android, Java, and Kotlin Multiplatform.",
+            "website": "https://github.com/square/okio/",
             "developers": [
                 {
                     "name": "Square, Inc."
                 }
             ],
-            "artifactVersion": "3.16.4",
-            "description": "A modern I/O library for Android, Java, and Kotlin Multiplatform.",
             "scm": {
                 "connection": "scm:git:git://github.com/square/okio.git",
-                "url": "https://github.com/square/okio/",
-                "developerConnection": "scm:git:ssh://git@github.com/square/okio.git"
+                "developerConnection": "scm:git:ssh://git@github.com/square/okio.git",
+                "url": "https://github.com/square/okio/"
             },
-            "name": "okio",
-            "website": "https://github.com/square/okio/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-client-core",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-client-core",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-client-core",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-events",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-events",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-events",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-http",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-http",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-http",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-http-cio",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-http-cio",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-http-cio",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-io",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-io",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-io",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-serialization",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-serialization",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-serialization",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-sse",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-sse",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-sse",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-utils",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-utils",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-utils",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-websocket-serialization",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-websocket-serialization",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-websocket-serialization",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "io.ktor:ktor-websockets",
-            "funding": [
-                
-            ],
+            "artifactVersion": "3.5.1",
+            "name": "ktor-websockets",
+            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
+            "website": "https://github.com/ktorio/ktor",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Jetbrains Team"
+                    "name": "Jetbrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "3.4.0",
-            "description": "Ktor is a framework for quickly creating web applications in Kotlin with minimal effort.",
             "scm": {
                 "url": "https://github.com/ktorio/ktor.git"
             },
-            "name": "ktor-websockets",
-            "website": "https://github.com/ktorio/ktor",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlin:kotlin-stdlib",
-            "funding": [
-                
-            ],
+            "artifactVersion": "2.3.21",
+            "name": "Kotlin Stdlib",
+            "description": "Kotlin Standard Library",
+            "website": "https://kotlinlang.org/",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Kotlin Team"
+                    "name": "Kotlin Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "2.3.10",
-            "description": "Kotlin Standard Library",
             "scm": {
                 "connection": "scm:git:https://github.com/JetBrains/kotlin.git",
-                "url": "https://github.com/JetBrains/kotlin",
-                "developerConnection": "scm:git:https://github.com/JetBrains/kotlin.git"
+                "developerConnection": "scm:git:https://github.com/JetBrains/kotlin.git",
+                "url": "https://github.com/JetBrains/kotlin"
             },
-            "name": "Kotlin Stdlib",
-            "website": "https://kotlinlang.org/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlin:kotlin-stdlib-common",
-            "funding": [
-                
-            ],
+            "artifactVersion": "2.3.21",
+            "name": "Kotlin Stdlib Common",
+            "description": "Kotlin Common Standard Library (legacy, use kotlin-stdlib instead)",
+            "website": "https://kotlinlang.org/",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "Kotlin Team"
+                    "name": "Kotlin Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "2.3.10",
-            "description": "Kotlin Common Standard Library (legacy, use kotlin-stdlib instead)",
             "scm": {
                 "connection": "scm:git:https://github.com/JetBrains/kotlin.git",
-                "url": "https://github.com/JetBrains/kotlin",
-                "developerConnection": "scm:git:https://github.com/JetBrains/kotlin.git"
+                "developerConnection": "scm:git:https://github.com/JetBrains/kotlin.git",
+                "url": "https://github.com/JetBrains/kotlin"
             },
-            "name": "Kotlin Stdlib Common",
-            "website": "https://kotlinlang.org/",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:atomicfu",
-            "funding": [
-                
-            ],
+            "artifactVersion": "0.23.1",
+            "name": "atomicfu",
+            "description": "AtomicFU utilities",
+            "website": "https://github.com/Kotlin/kotlinx.atomicfu",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "0.23.1",
-            "description": "AtomicFU utilities",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx.atomicfu"
             },
-            "name": "atomicfu",
-            "website": "https://github.com/Kotlin/kotlinx.atomicfu",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-coroutines-core",
-            "funding": [
-                
-            ],
+            "artifactVersion": "1.11.0",
+            "name": "kotlinx-coroutines-core",
+            "description": "Coroutines support libraries for Kotlin",
+            "website": "https://github.com/Kotlin/kotlinx.coroutines",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "1.10.2",
-            "description": "Coroutines support libraries for Kotlin",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx.coroutines"
             },
-            "name": "kotlinx-coroutines-core",
-            "website": "https://github.com/Kotlin/kotlinx.coroutines",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-datetime",
-            "funding": [
-                
-            ],
+            "artifactVersion": "0.8.0-0.6.x-compat",
+            "name": "kotlinx-datetime",
+            "description": "Kotlin Datetime Library",
+            "website": "https://github.com/Kotlin/kotlinx-datetime",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "0.7.1-0.6.x-compat",
-            "description": "Kotlin Datetime Library",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx-datetime"
             },
-            "name": "kotlinx-datetime",
-            "website": "https://github.com/Kotlin/kotlinx-datetime",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-io-bytestring",
-            "funding": [
-                
-            ],
+            "artifactVersion": "0.9.0",
+            "name": "kotlinx-io-bytestring",
+            "description": "IO support for Kotlin",
+            "website": "https://github.com/Kotlin/kotlinx-io",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "0.8.2",
-            "description": "IO support for Kotlin",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx-io"
             },
-            "name": "kotlinx-io-bytestring",
-            "website": "https://github.com/Kotlin/kotlinx-io",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-io-core",
-            "funding": [
-                
-            ],
+            "artifactVersion": "0.9.0",
+            "name": "kotlinx-io-core",
+            "description": "IO support for Kotlin",
+            "website": "https://github.com/Kotlin/kotlinx-io",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "0.8.2",
-            "description": "IO support for Kotlin",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx-io"
             },
-            "name": "kotlinx-io-core",
-            "website": "https://github.com/Kotlin/kotlinx-io",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-serialization-core",
-            "funding": [
-                
-            ],
+            "artifactVersion": "1.11.0",
+            "name": "kotlinx-serialization-core",
+            "description": "Kotlin multiplatform serialization runtime library",
+            "website": "https://github.com/Kotlin/kotlinx.serialization",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "1.10.0",
-            "description": "Kotlin multiplatform serialization runtime library",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx.serialization"
             },
-            "name": "kotlinx-serialization-core",
-            "website": "https://github.com/Kotlin/kotlinx.serialization",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         },
         {
             "uniqueId": "org.jetbrains.kotlinx:kotlinx-serialization-json",
-            "funding": [
-                
-            ],
+            "artifactVersion": "1.11.0",
+            "name": "kotlinx-serialization-json",
+            "description": "Kotlin multiplatform serialization runtime library",
+            "website": "https://github.com/Kotlin/kotlinx.serialization",
             "developers": [
                 {
-                    "organisationUrl": "https://www.jetbrains.com",
-                    "name": "JetBrains Team"
+                    "name": "JetBrains Team",
+                    "organisationUrl": "https://www.jetbrains.com"
                 }
             ],
-            "artifactVersion": "1.10.0",
-            "description": "Kotlin multiplatform serialization runtime library",
             "scm": {
                 "url": "https://github.com/Kotlin/kotlinx.serialization"
             },
-            "name": "kotlinx-serialization-json",
-            "website": "https://github.com/Kotlin/kotlinx.serialization",
             "licenses": [
                 "Apache-2.0"
+            ],
+            "funding": [
+                
             ]
         }
     ],
     "licenses": {
         "Apache-2.0": {
-            "content": "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n\"License\" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\n\n\"Licensor\" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\n\n\"Legal Entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\n\n\"You\" (or \"Your\") shall mean an individual or Legal Entity exercising permissions granted by this License.\n\n\"Source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\n\n\"Object\" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\n\n\"Work\" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\n\n\"Derivative Works\" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\n\n\"Contribution\" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as \"Not a Contribution.\"\n\n\"Contributor\" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\n\n     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and\n\n     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and\n\n     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\n\n     (d) If the Work includes a \"NOTICE\" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.\n\n     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\nTo apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets \"[]\" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same \"printed page\" as the copyright notice for easier identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
-            "hash": "Apache-2.0",
-            "internalHash": "Apache-2.0",
+            "name": "Apache License 2.0",
             "url": "https://spdx.org/licenses/Apache-2.0.html",
+            "content": "Apache License\nVersion 2.0, January 2004\nhttp://www.apache.org/licenses/\n\nTERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\n1. Definitions.\n\n\"License\" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.\n\n\"Licensor\" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.\n\n\"Legal Entity\" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, \"control\" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.\n\n\"You\" (or \"Your\") shall mean an individual or Legal Entity exercising permissions granted by this License.\n\n\"Source\" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.\n\n\"Object\" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.\n\n\"Work\" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).\n\n\"Derivative Works\" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.\n\n\"Contribution\" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, \"submitted\" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as \"Not a Contribution.\"\n\n\"Contributor\" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.\n\n2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.\n\n3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.\n\n4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:\n\n     (a) You must give any other recipients of the Work or Derivative Works a copy of this License; and\n\n     (b) You must cause any modified files to carry prominent notices stating that You changed the files; and\n\n     (c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and\n\n     (d) If the Work includes a \"NOTICE\" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.\n\n     You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.\n\n5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.\n\n6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.\n\n7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an \"AS IS\" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.\n\n8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.\n\n9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.\n\nEND OF TERMS AND CONDITIONS\n\nAPPENDIX: How to apply the Apache License to your work.\n\nTo apply the Apache License to your work, attach the following boilerplate notice, with the fields enclosed by brackets \"[]\" replaced with your own identifying information. (Don't include the brackets!)  The text should be enclosed in the appropriate comment syntax for the file format. We also recommend that a file or class name and description of purpose be included on the same \"printed page\" as the copyright notice for easier identification within third-party archives.\n\nCopyright [yyyy] [name of copyright owner]\n\nLicensed under the Apache License, Version 2.0 (the \"License\");\nyou may not use this file except in compliance with the License.\nYou may obtain a copy of the License at\n\nhttp://www.apache.org/licenses/LICENSE-2.0\n\nUnless required by applicable law or agreed to in writing, software\ndistributed under the License is distributed on an \"AS IS\" BASIS,\nWITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\nSee the License for the specific language governing permissions and\nlimitations under the License.",
+            "internalHash": "Apache-2.0",
             "spdxId": "Apache-2.0",
-            "name": "Apache License 2.0"
+            "hash": "Apache-2.0"
         },
         "MIT": {
-            "content": "MIT License\n\nCopyright (c) <year> <copyright holders>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
-            "hash": "MIT",
-            "internalHash": "MIT",
+            "name": "MIT License",
             "url": "https://spdx.org/licenses/MIT.html",
+            "content": "MIT License\n\nCopyright (c) <year> <copyright holders>\n\nPermission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the \"Software\"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:\n\nThe above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.\n\nTHE SOFTWARE IS PROVIDED \"AS IS\", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.",
+            "internalHash": "MIT",
             "spdxId": "MIT",
-            "name": "MIT License"
+            "hash": "MIT"
         }
     }
 }


### PR DESCRIPTION
## Summary
- `docs/commands.md` was stale (old version, old dependency versions in the `--about` dump) and used the wrong code-fence language tag (`` ```dtd ``). Regenerated from real, freshly-built CLI output (`--help`/`--version`/`--about` + every subcommand `--help`); fences fixed to `` ```text ``.
- `src/nativeMain/resources/librariesandlicenses.json` was behind the version catalog (okio 3.16.4 vs 3.17.0, ktor 3.4.0 vs 3.5.1, etc.), so shipped `--about` output reported wrong versions, with nothing preventing it from drifting again on future dependency bumps. Regenerated the JSON, and wired every `generate*BuildConfigClasses` task to `dependsOn("exportLibraryDefinitions")` (with `mustRunAfter` added to `*ProcessResources` tasks to resolve the resulting Gradle output-overlap validation) so a plain `./gradlew build` now regenerates it automatically — verified end-to-end by deliberately staling the JSON and confirming a normal build task regenerates it correctly without manual intervention.
- The six tracked `docs/superpowers/plans/*.md` internal planning docs were reachable on the published docs site (`mkdocs gh-deploy` publishes everything under `docs/`, even files absent from `nav`). Added `exclude_docs: | \n  superpowers/` to `mkdocs.yml`; verified with a real `mkdocs build` that no `superpowers/*` content appears in the built site output. The plan files themselves are untouched, just no longer published.
- Closes CODEBASE_REVIEW.md §4.4 (Medium).

## Test plan
- [x] `./gradlew build` passes from a clean state.
- [x] Freshness wiring independently re-verified: staled the JSON, ran a normal build task, confirmed automatic regeneration (not just a one-off manual export).
- [x] Regenerated JSON versions spot-checked against `settings.gradle.kts`'s catalog (okio, ktor, clikt all match).
- [x] `docs/commands.md` example blocks diffed programmatically against real binary output — byte-for-byte match.
- [x] Real `mkdocs build` confirms `docs/superpowers/` is excluded from the published site.

Reviewed via subagent-driven-development: implementer + independent reviewer, both re-verified the build-wiring and doc regeneration first-hand rather than trusting reports. No blocking findings (one informational note: `kotlin-stdlib` resolves to 2.3.21 via Gradle version conflict resolution even though the `kotlin` plugin itself is pinned to 2.3.10 — legitimate, unrelated to this change).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>